### PR TITLE
Clarify `social-info: mild`

### DIFF
--- a/docs/generate.html
+++ b/docs/generate.html
@@ -681,7 +681,7 @@ function updateAppData() {
         </p>
         <select class="form-control" id="social-info" required>
           <option value="none">None</option>
-          <option value="mild">Checking for the latest application version (typically acting as a user-counter)</option>
+          <option value="mild">Using any online API, e.g. a user-counter</option>
           <option value="moderate">Sharing diagnostic data not identifiable to the user, e.g. profiling data</option>
           <option value="intense">Sharing information identifiable to the user, e.g. crash dumps</option>
         </select>


### PR DESCRIPTION
This expands the scope of the `mild` case a bit by being more explicit about using _any_ online API (not just "checking for a new version"). Fixes #22