### PR TITLE
Expose content questions for apps; hide social questions for offline apps

### DIFF
--- a/docs/generate.html
+++ b/docs/generate.html
@@ -187,7 +187,7 @@ function updateAppData() {
       kinds:    ['game-online', 'game-offline', 'app-online', 'app-offline']
     },
     { section:  'social',
-      kinds:    ['game-online', 'app-online', 'app-offline']
+      kinds:    ['game-online', 'app-online']
     },
     { section:  'money',
       kinds:    ['game-online', 'game-offline', 'app-online', 'app-offline']

--- a/docs/generate.html
+++ b/docs/generate.html
@@ -175,16 +175,16 @@ function updateAppData() {
   // hide tabs when not required
   var sections = [
     { section:  'violence',
-      kinds:    ['game-online', 'game-offline']
+      kinds:    ['game-online', 'game-offline', 'app-online', 'app-offline']
     },
     { section:  'drugs',
-      kinds:    ['game-online', 'game-offline']
+      kinds:    ['game-online', 'game-offline', 'app-online', 'app-offline']
     },
     { section:  'sex',
-      kinds:    ['game-online', 'game-offline']
+      kinds:    ['game-online', 'game-offline', 'app-online', 'app-offline']
     },
     { section:  'language',
-      kinds:    ['game-online', 'game-offline']
+      kinds:    ['game-online', 'game-offline', 'app-online', 'app-offline']
     },
     { section:  'social',
       kinds:    ['game-online', 'app-online', 'app-offline']


### PR DESCRIPTION
As discussed on #30, there are non-game apps which contain examples of the content in these categories.

While making this change I noticed that offline apps are shown the social questions – I think this is unnecessary and included another change to address that.

Fixes #30.