### PR TITLE
specification: Add a specification of OARS 1.1

### DIFF
--- a/specification/meson.build
+++ b/specification/meson.build
@@ -1,0 +1,11 @@
+rnv = find_program('rnv')
+
+# Validate the RelaxNG Compact schemas.
+# In order to validate a particular XML AppData file snippet against the
+# schemas, use `rnv -q oars-1.1.rnc ${my_file}` or pass it on stdin.
+test('oars-1.0-rnc-check', rnv,
+  args : ['-c', 'oars-1.0.rnc'],
+)
+test('oars-1.1-rnc-check', rnv,
+  args : ['-c', 'oars-1.1.rnc'],
+)

--- a/specification/oars-1.0.rnc
+++ b/specification/oars-1.0.rnc
@@ -1,0 +1,32 @@
+start = content_rating
+
+content_rating = element content_rating {
+  attribute type { "oars-1.0" },
+  content_attribute*
+}
+content_attribute = element content_attribute {
+  attribute id { ids },
+  values
+}
+
+values = "unknown" | "none" | "mild" | "moderate" | "intense"
+ids = "drugs-alcohol" |
+      "drugs-narcotics" |
+      "drugs-tobacco" |
+      "language-discrimination" |
+      "language-humor" |
+      "language-profanity" |
+      "money-gambling" |
+      "money-purchasing" |
+      "sex-nudity" |
+      "sex-themes" |
+      "social-audio" |
+      "social-chat" |
+      "social-contacts" |
+      "social-info" |
+      "social-location" |
+      "violence-bloodshed" |
+      "violence-cartoon" |
+      "violence-fantasy" |
+      "violence-realistic" |
+      "violence-sexual"

--- a/specification/oars-1.1.md
+++ b/specification/oars-1.1.md
@@ -1,0 +1,90 @@
+OARS 1.0 and 1.1 specification
+===
+
+This specification gives the semantics for the OARS 1.0–1.1 XML format. The
+structure of the format is specified in the
+[accompanying XML schema](./oars-1.1.rng).
+
+Future versions of the format may change structure or semantics in incompatible
+ways.
+
+Version strings
+---
+
+This specification refers to OARS versions identified by the strings:
+ * `oars-1.0`
+ * `oars-1.1`
+
+The only difference between the two is that OARS 1.1 supports more attributes
+than OARS 1.0.
+
+Semantics
+---
+
+An OARS content rating consists of zero or more content attributes. Each content
+attribute has as its value the ‘intensity’ of that type of content present in
+the application being described.
+
+The following intensities are allowed:
+ * `unknown`
+ * `none`
+ * `mild`
+ * `moderate`
+ * `intense`
+
+The semantics for each intensity depend on the attribute the intensity
+describes, but in all cases, `intense` is the most intense, `none` is the least
+intense, and `unknown` is used to indicate that no intensity is known for that
+attribute.
+
+Each version of OARS describes a fixed set of attributes, and the content rating
+for a particular application can provide values for none, some or all of those
+attributes. If an attribute is not present in a content rating, its value must
+be assumed to be `none`. If no content rating is provided for an application at
+all, however, the value of all attributes (in any version of OARS) must be
+assumed to be `unknown`.
+
+Examples
+---
+
+```
+<content_rating type="oars-1.1">
+  <content_attribute id="language-profanity">none</content_attribute>
+  <content_attribute id="money-purchasing">intense</content_attribute>
+  <content_attribute id="sex-themes">mild</content_attribute>
+</content_rating>
+```
+
+This example describes an application where `money-purchasing` is `intense`,
+`sex-themes` is `mild`, and all other attributes (including, specifically,
+`language-profanity`) are `none`.
+
+It is equivalent to the following content rating:
+```
+<content_rating type="oars-1.1">
+  <content_attribute id="money-purchasing">intense</content_attribute>
+  <content_attribute id="sex-themes">mild</content_attribute>
+</content_rating>
+```
+
+---
+
+```
+<content_rating type="oars-1.1"/>
+```
+
+This example describes an application where *all* attributes have value `none`.
+
+In contrast, if the `type` were specified as `oars-1.0`, only the attributes
+present in OARS 1.0 would have value `none`. The attributes only present in
+later versions of the OARS specification would have value `unknown`.
+
+---
+
+```
+<!-- No <content_rating/> element present. -->
+```
+
+This example represents some AppData which doesn’t contain a `<content_rating/>`
+element. In that case, *all* attributes (from any version of the OARS
+specification) have value `unknown`.

--- a/specification/oars-1.1.rnc
+++ b/specification/oars-1.1.rnc
@@ -1,0 +1,40 @@
+start = content_rating
+
+content_rating = element content_rating {
+  attribute type { "oars-1.1" },
+  content_attribute*
+}
+content_attribute = element content_attribute {
+  attribute id { ids },
+  values
+}
+
+values = "unknown" | "none" | "mild" | "moderate" | "intense"
+ids = "drugs-alcohol" |
+      "drugs-narcotics" |
+      "drugs-tobacco" |
+      "language-discrimination" |
+      "language-humor" |
+      "language-profanity" |
+      "money-gambling" |
+      "money-purchasing" |
+      "sex-adultery" |
+      "sex-appearance" |
+      "sex-homosexuality" |
+      "sex-nudity" |
+      "sex-prostitution" |
+      "sex-themes" |
+      "social-audio" |
+      "social-chat" |
+      "social-contacts" |
+      "social-info" |
+      "social-location" |
+      "violence-bloodshed" |
+      "violence-cartoon" |
+      "violence-desecration" |
+      "violence-fantasy" |
+      "violence-realistic" |
+      "violence-sexual" |
+      "violence-slavery" |
+      "violence-worship"
+


### PR DESCRIPTION
Add a prose specification of the semantics of OARS 1.0 and 1.1, and
RelaxNG Compact schemas of the structure of both.

The semantics are based on the behaviour of the generator, which was
previously the canonical standard.

Add a `meson.build` with tests to validate the schemas, although this is
only present as documentation for the time being, since there’s no build
system for the module as a whole.

Signed-off-by: Philip Withnall <withnall@endlessm.com>