### PR TITLE
Add OpenStore to the index

### DIFF
--- a/docs/icons/openstore.svg
+++ b/docs/icons/openstore.svg
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="512"
+   height="512"
+   viewBox="0 0 512.00001 512.00001"
+   id="svg5962"
+   version="1.1"
+   inkscape:version="0.92.1 r"
+   sodipodi:docname="logo.svg"
+   inkscape:export-filename="/home/brian/dev/web/openstore-web/www/img/logo.png"
+   inkscape:export-xdpi="48"
+   inkscape:export-ydpi="48">
+  <defs
+     id="defs5964" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="241.05258"
+     inkscape:cy="256.67235"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5967">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(396,-510.64792)">
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#292929;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect5957"
+       width="512"
+       height="512"
+       x="-396"
+       y="510.64792"
+       inkscape:export-xdpi="45"
+       inkscape:export-ydpi="45"
+       inkscape:export-filename="/home/michal/Devel/BigText/BigMovingText.png" />
+    <path
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:12.0041132px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Medium';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#f7f7f7;fill-opacity:1;stroke:none;enable-background:new"
+       d="m -168.59375,614.14792 -1.09017,2.31661 c -9.9759,21.13501 -19.46128,42.83725 -28.86628,64.53843 -9.40259,21.70122 -19.1827,45.06146 -28.86625,69.0351 -2.69911,6.88463 -5.44336,14.05924 -8.16859,21.10706 l 61.41185,0 c 4.97743,-13.13851 9.87186,-25.89339 14.42935,-37.86033 7.02218,-17.82625 13.26517,-32.25924 18.92624,-45.61219 5.41765,12.90428 10.90019,26.6892 17.8361,44.52956 4.75638,12.233 9.60795,25.4309 14.5732,38.94296 l 62.766943,0 c -2.87426,-7.05589 -5.797541,-14.22527 -8.577369,-21.10706 -9.404127,-23.98776 -18.231117,-47.31916 -27.639873,-69.0351 -9.405279,-21.70111 -19.026931,-43.407 -29.002541,-64.53843 l -1.09017,-2.31661 -56.64244,0 z m -102.12594,170.19994 c -19.31108,0 -34.85457,15.55065 -34.85457,34.86187 0,19.3112 15.54349,34.85458 34.85457,34.85458 l 261.4393915,0 c 19.3111375,0 34.8545615,-15.54338 34.8545615,-34.85458 0,-19.31122 -15.543424,-34.86187 -34.8545615,-34.86187 l -261.4393915,0 z m 0,17.42728 152.50758,0 c 9.65568,0 17.4273,7.77917 17.4273,17.43459 0,9.65579 -7.77162,17.42727 -17.4273,17.42727 l -152.50758,0 c -9.65565,0 -17.42726,-7.77148 -17.42726,-17.42727 0,-9.65542 7.77161,-17.43459 17.42726,-17.43459 z m -0.53752,65.49956 c -5.2212,14.84394 -10.59032,30.27062 -16.20842,46.29335 l -2.18029,5.57987 64.40976,0 13.33918,-36.76234 c 1.82805,-5.00719 3.70443,-10.04591 5.45079,-15.11088 l -64.2735,0 c -0.18213,0 -0.35578,10e-4 -0.53752,0 z m 195.114331,0 c 1.725842,5.13119 3.470656,10.18485 5.314483,15.11088 4.251187,11.35922 8.287881,22.9393 12.25664,34.58241 l 0.946297,2.17993 3.406733,0 64.538468,0 -2.3090391,-5.57987 C 2.3833234,897.51986 -3.1737917,882.09886 -8.6064894,867.2747 c -0.2269658,0.003 -0.4459965,0 -0.6738091,0 l -66.8625805,0 z"
+       id="path2996"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="guides"
+     sodipodi:insensitive="true"
+     style="display:none">
+    <path
+       sodipodi:nodetypes="sssssssss"
+       inkscape:connector-curvature="0"
+       id="path3774"
+       d="m 166.05406,17.999974 179.89189,0 c 145.29729,0 166.05406,20.73726 166.05406,165.899046 l 0,144.20253 c 0,145.16118 -20.75677,165.89848 -166.05406,165.89848 l -179.89189,0 C 20.756747,494.00003 -7.5e-6,473.26273 -7.5e-6,328.10155 l 0,-144.20253 C -7.5e-6,38.737234 20.756747,17.999974 166.05406,17.999974 Z"
+       style="display:inline;fill:#0000ff;fill-opacity:0.08118083;stroke:#0000ff;enable-background:new" />
+    <circle
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#0000ff;fill-opacity:0.08118083;stroke:#0000ff;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
+       id="path4118"
+       cx="256"
+       cy="256"
+       r="143.99997" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#0000ff;fill-opacity:0.08118083;stroke:#0000ff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4152"
+       width="272"
+       height="272"
+       x="120"
+       y="120" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#0000ff;fill-opacity:0.08118083;stroke:#0000ff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4154"
+       width="304"
+       height="240"
+       x="104"
+       y="136" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#0000ff;fill-opacity:0.08118083;stroke:#0000ff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4156"
+       width="240"
+       height="304"
+       x="136"
+       y="104" />
+  </g>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -142,6 +142,17 @@
           <div class="col-md-6 col-lg-4 mb-3">
             <div class="card">
               <div class="card-body text-center">
+                <img class="mb-3" src="icons/openstore.svg" style="width: 128px;" />
+                <h5>OpenStore</h5>
+                <p>The open source software repository for Ubuntu Touch.</p>
+                <a href="https://open-store.io/" target="_blank">Learn More</a>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-md-6 col-lg-4 mb-3">
+            <div class="card">
+              <div class="card-body text-center">
                 <img class="mb-3" src="icons/dialog-question.png" style="width: 128px;" />
                 <h5>Your Project</h5>
                 <p>Using OARS for distributing software? Add your project here.</p>


### PR DESCRIPTION
The [OpenStore](https://next.open-store.io/) recently started including OARS data for Ubuntu Touch apps, thanks for considering to include this!

- https://gitlab.com/theopenstore/openstore/-/blob/master/packages/openstore-web/src/components/apps/ContentRating.astro?ref_type=heads#L231
- https://gitlab.com/theopenstore/openstore-app/-/blob/master/qml/Components/ContentRating.qml#L353